### PR TITLE
fix bug with ArNS balance when undefined

### DIFF
--- a/app/src/services/registry.js
+++ b/app/src/services/registry.js
@@ -35,7 +35,9 @@ export async function register({ name, owner, transactionId }) {
     return { ok: false, message: `This name ${name} is already taken and is not available for purchase` }
   }
 
-  if (registryState.balances[owner] < registryState.fees[name.length]) {
+  const arnsBalance = registryState.balances[owner]
+
+  if (typeof arnsBalance === 'undefined' || arnsBalance < registryState.fees[name.length]) {
     return { ok: false, message: `Not enough ArNS Test Token to purchase this subdomain.` }
   }
 

--- a/app/src/services/registry.js
+++ b/app/src/services/registry.js
@@ -90,7 +90,7 @@ export async function getBalance(owner) {
 
   const result = await registry.readState().then(path(['cachedValue', 'state', 'balances', owner]))
     .catch(e => console.log(e.message))
-  return result
+  return result ?? 0
 }
 
 export async function getFees(subdomain = '') {


### PR DESCRIPTION
### Issue

- When a wallet address hasn't ever received ArNS test tokens, the ArNS balance value for the address is `undefined` and [`registryState.balances[owner] < registryState.fees[name.length]`](https://github.com/twilson63/permapages/blob/bc84f6b4b09f20660328e9946978f59c156f59de/app/src/services/registry.js#L38) becomes `false` when the `registryState.balances[owner]` is `undefined` so it does not prevent the user to create a subdomain. And it seems a subdomain is created but it does not work.

- Also, the ArNS balance is shown as undefined on the UI when a wallet address hasn't ever received ArNS test tokens.

### Fix

- Check if `registryState.balances[owner]` is undefined or less than the required fees then return an error message.
- Return the ArNS balance as 0 when it is undefined.

